### PR TITLE
Aligned namespaces with Assembly names

### DIFF
--- a/FsUno.Domain/CommandHandler.fs
+++ b/FsUno.Domain/CommandHandler.fs
@@ -1,4 +1,4 @@
-﻿module CommandHandlers
+﻿module FsUno.Domain.CommandHandlers
 
 open Game
 
@@ -10,7 +10,6 @@ open Game
 // then simply maintain state and save new events to the store.
 // This is usually ok for aggregates with a small number of events
 module Game =
-
     type Agent<'T> = MailboxProcessor<'T>
     let create readStream appendToStream =
 
@@ -66,4 +65,3 @@ module Game =
 
         fun command -> 
             dispatcher.Post command
-        

--- a/FsUno.Domain/Deck.fs
+++ b/FsUno.Domain/Deck.fs
@@ -1,4 +1,4 @@
-﻿module Deck
+﻿module FsUno.Domain.Deck
 
 [<Struct>]
 type Digit =
@@ -24,5 +24,3 @@ type Card =
 type Direction =
     | ClockWise
     | CounterClockWise
-
-

--- a/FsUno.Domain/EventHandler.fs
+++ b/FsUno.Domain/EventHandler.fs
@@ -1,8 +1,9 @@
-﻿namespace FsUno
+﻿namespace FsUno.Domain
 
-open System
 open Deck
 open Game
+
+open System
 
 type EventHandler() =
     let mutable turnCount = 0
@@ -28,13 +29,11 @@ type EventHandler() =
     let printer f (w:IO.TextWriter) v = w.Write(f v : string)
     let cardPrinter = printer printCard
 
-    member this.Handle =
-        function
+    member this.Handle = function
         | GameStarted event ->
             printfn "Game %O started with %d players" event.GameId event.PlayerCount
             setColor event.FirstCard
             printfn "First card: %A" event.FirstCard
-
         | CardPlayed event ->
             turnCount <- turnCount + 1
             setColor event.Card

--- a/FsUno.Domain/Game.fs
+++ b/FsUno.Domain/Game.fs
@@ -1,4 +1,4 @@
-﻿module Game
+﻿module FsUno.Domain.Game
 
 open Deck
 
@@ -23,8 +23,7 @@ and PlayCard = {
     Card: Card }
 
 
-let gameId =
-    function
+let gameId = function
     | StartGame c -> c.GameId
     | PlayCard c -> c.GameId
     
@@ -79,7 +78,6 @@ module Turn =
 
     let player (current, _) = current
 
-[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module Direction =
     let reverse = function
         | ClockWise -> CounterClockWise
@@ -97,7 +95,7 @@ let empty = {
     TopCard = Digit(digit 0,Red) 
     Direction = ClockWise}
 
-// Operations on the DiscardPile aggregate
+// Operations on the Game aggregate
 
 let color = function
     | Digit(_,c) -> c
@@ -111,8 +109,8 @@ let (|SameValue|_|) = function
     | _ -> None
 
 let startGame (command: StartGame) state =
-    if command.PlayerCount <= 2 then invalidArg "playerCount" "You should be at least 3 players"
-    if state.GameAlreadyStarted then invalidOp "You cannot start game twice"
+    if command.PlayerCount <= 2 then invalidArg "playerCount" "There should be at least 3 players"
+    if state.GameAlreadyStarted then invalidOp "The game cannot be started more than once"
 
     [ GameStarted { GameId = command.GameId
                     PlayerCount = command.PlayerCount
@@ -155,34 +153,18 @@ let playCard (command: PlayCard) state =
 
 // Map commands to aggregates operations
 
-let handle =
-    function
+let handle = function
     | StartGame command -> startGame command
     | PlayCard command -> playCard command
 
-
-
-
-
-
-
-
-
-
-
-
-
-
 // Applies state changes for events
 
-let apply state =
-    function
+let apply state = function
     | GameStarted event -> 
         { GameAlreadyStarted = true
           Player = Turn.start event.PlayerCount
           TopCard = event.FirstCard 
           Direction = ClockWise }
-
     | CardPlayed event ->
         { state with
             Player = state.Player |> Turn.set event.NextPlayer
@@ -195,5 +177,3 @@ let apply state =
 // Replays all events from start to get current state
 
 let replay events = List.fold apply empty events
-
-

--- a/FsUno.Persistence.EventStore/EventStore.fs
+++ b/FsUno.Persistence.EventStore/EventStore.fs
@@ -1,7 +1,7 @@
 ﻿module EventStore
 
 open System
-open Game
+open FsUno.Domain.Game
 
 // This module implements AwaitTask for non generic Task
 // It should be useless in F# 4 since it should be implemented in FSharp.Core
@@ -80,6 +80,3 @@ let appendToStream (store: IEventStoreConnection) streamId expectedVersion newEv
         let serializedEvents = [| for event in newEvents -> serialize event |]
 
         do! store.AsyncAppendToStream streamId expectedVersion serializedEvents }
-
-
-

--- a/FsUno.Persistence.EventStore/Serialization.fs
+++ b/FsUno.Persistence.EventStore/Serialization.fs
@@ -1,5 +1,7 @@
 ﻿module Serialization
 
+open FsUno.Domain
+
 // This module provides Json serialization to store
 // events in the event store 
 
@@ -85,7 +87,6 @@ module private Json =
         name
 
     let deserializeUnion (r: JsonReader) (s:JsonSerializer) getCase =
-
         if r.TokenType = JsonToken.StartObject then
             read r
             let case = getCase r true
@@ -219,5 +220,3 @@ let serializeUnion (o:'a)  =
     serializer.Serialize(writer, o)
     writer.Flush()
     case.Name, stream.ToArray()
-
-

--- a/FsUno.Tests/Builders.fs
+++ b/FsUno.Tests/Builders.fs
@@ -1,6 +1,7 @@
 ﻿[<AutoOpen>]
-module Builders
+module FsUno.Tests.Builders
 
+open FsUno.Domain
 open Deck
 
 let red n = Digit(digit n, Red)

--- a/FsUno.Tests/PrettyPrint.fs
+++ b/FsUno.Tests/PrettyPrint.fs
@@ -1,24 +1,22 @@
-﻿module PrettyPrint
+﻿module FsUno.Tests.PrettyPrint
 
+open FsUno.Domain
 open Deck
 open Game
 
-let printCard =
-    function
+let printCard = function
     | Digit(n, color) -> sprintf "%A %O" color n
     | KickBack(color) -> sprintf "%A Kickback" color
     
 let cardPrinter () = printCard
 
-let printEvent =
-    function
+let printEvent = function
     | GameStarted e -> sprintf "Game %O started with %d players. Top Card is %a" e.GameId e.PlayerCount cardPrinter e.FirstCard
     | CardPlayed e -> sprintf "Player %d played %a" e.Player cardPrinter e.Card
     | PlayerPlayedAtWrongTurn e -> sprintf "Player %d playerd at wrong turn a %a" e.Player cardPrinter e.Card 
     | DirectionChanged e -> sprintf "Game direction changed to %A" e.Direction
 
-let printCommand  =
-    function
+let printCommand = function
     | StartGame c -> sprintf "Start game %O with %d players. Top card %a" c.GameId c.PlayerCount cardPrinter c.FirstCard
     | PlayCard c -> sprintf "Player %d plays %a" c.Player cardPrinter c.Card
 

--- a/FsUno.Tests/Specification.fs
+++ b/FsUno.Tests/Specification.fs
@@ -1,9 +1,10 @@
-﻿module Specifications
+﻿module FsUno.Tests.Specifications
 
-
-open FsUnit.Xunit
+open FsUno.Domain
 open Game
+
 open PrettyPrint
+open FsUnit.Xunit
 
 let Given (events: Event list) = events
 let When (command: Command) events = events, command
@@ -27,4 +28,3 @@ let ExpectThrows<'Ex> (events, command) =
         |> handle command
         |> ignore)
     |> should throw typeof<'Ex>
-

--- a/FsUno.Tests/When building a digit.fs
+++ b/FsUno.Tests/When building a digit.fs
@@ -1,9 +1,11 @@
-﻿module ``When building a digit``
+﻿module FsUno.Tests.``When building a digit``
 
+open FsUno.Domain
+open Deck
+
+open FsUnit.Xunit
 open System
 open Xunit
-open FsUnit.Xunit
-open Deck
 
 [<Fact>]
 let ``0 should be constructable``() =

--- a/FsUno.Tests/When passing to next turn.fs
+++ b/FsUno.Tests/When passing to next turn.fs
@@ -1,9 +1,11 @@
-﻿module ``When passing to next turn``
+﻿module FsUno.Tests.``When passing to next turn``
 
-open Xunit
-open FsUnit.Xunit
+open FsUno.Domain
 open Deck
 open Game
+
+open FsUnit.Xunit
+open Xunit
 
 [<Fact>]
 let ``clockwise should be next one``() =

--- a/FsUno.Tests/When playing a kickback.fs
+++ b/FsUno.Tests/When playing a kickback.fs
@@ -1,10 +1,11 @@
-﻿module ``When playing a kickback``
+﻿module FsUno.Tests.``When playing a kickback``
 
-open Xunit
-open FsUnit.Xunit
-open Specifications
+open FsUno.Domain
 open Deck
 open Game
+
+open Specifications
+open Xunit
 
 let gameId = GameId 1
 

--- a/FsUno.Tests/When playing a second turn.fs
+++ b/FsUno.Tests/When playing a second turn.fs
@@ -1,10 +1,12 @@
 ﻿module FsUno.Tests.``When playing a second turn``
 
-open Xunit
-open System
-open Specifications
+open FsUno.Domain
 open Deck
 open Game
+
+open Specifications
+open System
+open Xunit
 
 let gameId = GameId 1
 

--- a/FsUno.Tests/When playing card.fs
+++ b/FsUno.Tests/When playing card.fs
@@ -1,12 +1,15 @@
 ﻿module FsUno.Tests.``When playing card``
 
-open Xunit
-open System
-open Specifications
+open FsUno.Domain
 open Deck
 open Game
 
+open Specifications
+open System
+open Xunit
+
 let gameId = GameId 1
+
 [<Fact>]
 let ``Same color should be accepted``() =
     Given [ GameStarted { GameId = gameId; PlayerCount = 4; FirstCard = red 3 } ]

--- a/FsUno.Tests/When serializing value.fs
+++ b/FsUno.Tests/When serializing value.fs
@@ -1,17 +1,18 @@
-﻿module ``When serializing value``
+﻿module FsUno.Tests.``When serializing value``
 
-open Xunit
-open FsUnit.Xunit
-open Game
+open FsUno.Domain.Game
+
 open Serialization
+
+open FsUnit.Xunit
 open Newtonsoft.Json
 open System.IO
+open Xunit
 
 let createSerializer converters =
     let serializer = JsonSerializer()
     converters |> List.iter serializer.Converters.Add
     serializer
-
 
 let serialize converters o = 
     let serializer = createSerializer converters

--- a/FsUno.Tests/When starting game.fs
+++ b/FsUno.Tests/When starting game.fs
@@ -1,10 +1,12 @@
 ﻿module FsUno.Tests.``When starting game``
 
-open Xunit
-open System
-open Specifications
+open FsUno.Domain
 open Deck
 open Game
+
+open Specifications
+open System
+open Xunit
 
 let gameId = GameId 1
 

--- a/FsUno/Program.fs
+++ b/FsUno/Program.fs
@@ -1,7 +1,6 @@
-﻿open FsUno
+﻿open FsUno.Domain
+
 open CommandHandlers
-
-
 open Deck
 open Game
 open EventStore


### PR DESCRIPTION
Main change is to have Namespaces be consistent with Assembly names. One thing this brings the fore (which I believe is for the best) is references to the Domain layer from the Persistence (which is obviously a separate concern). (the `.Domain` portion of the namespace is for me slightly ugly - I am currently personally experimenting with having 'Domain' assemblies have the simple names and then have e.g. a .Program or .App suffix on the outer app (this also sorts nicely in a flat list of projects) - happy to do some grunt work on that if any of that floats your boat)

Made formatting of `function`s consistent; please bat back if inconsistency is intentionally 'what feels best in a context'

Happy to split into separate SRP-honouring commits if desired

Also:
Minor improvements to messages
Removed straggler reference to `DiscardPile`
Removed blank lines
